### PR TITLE
build-pointers: use the unified rainix-copy-artifacts reusable

### DIFF
--- a/.github/workflows/build-pointers.yaml
+++ b/.github/workflows/build-pointers.yaml
@@ -2,4 +2,9 @@ name: build-pointers
 on: [push]
 jobs:
   build-pointers:
-    uses: rainlanguage/rainix/.github/workflows/rainix-build-pointers.yaml@main
+    # Unified artifact action (rainix#201): runs BuildPointers.sol (this repo
+    # has no CopyArtifacts.sol, so that step is skipped) and asserts the
+    # committed pointer artifacts still match. Replaces the retired
+    # rainix-build-pointers reusable. secrets: inherit carries CACHIX_AUTH_TOKEN.
+    uses: rainlanguage/rainix/.github/workflows/rainix-copy-artifacts.yaml@main
+    secrets: inherit


### PR DESCRIPTION
Repoint the pointer-artifact check at the unified `rainix-copy-artifacts` reusable (rainlanguage/rainix#201): it runs `BuildPointers.sol` (CopyArtifacts is skipped — no such script here) and asserts committed pointers still match. Replaces the standalone `rainix-build-pointers` reusable, being retired in favor of a single artifact action.

Adds `secrets: inherit` so `CACHIX_AUTH_TOKEN` flows through (the old caller didn't pass it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)