### PR TITLE
feat: add LibSnapshot — the shared per-release snapshot canon

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -27,7 +27,10 @@ cbor_metadata = false
 
 evm_version = "cancun"
 
-fs_permissions = [{ access = "read-write", path = "src/generated" }]
+fs_permissions = [
+  { access = "read", path = "foundry.toml" },
+  { access = "read-write", path = "src/generated" },
+]
 
 [fuzz]
 runs = 2048

--- a/src/lib/LibSnapshot.sol
+++ b/src/lib/LibSnapshot.sol
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity ^0.8.25;
+
+import {Vm} from "forge-std-1.16.1/src/Vm.sol";
+import {LibFs} from "./LibFs.sol";
+
+/// @title LibSnapshot
+/// @notice Freezes generated pointers files into per-release snapshots under
+/// `src/generated/<tag>/`, so every published release keeps an immutable record
+/// of its own deployment that consumers of that release can pin against, even
+/// after the current generated files advance to a newer release.
+///
+/// `LibFs` owns "write a generated file for a contract"; this owns "freeze that
+/// generated file for this release", one step later.
+///
+/// The immutability guard ships WITH the mechanism deliberately: freezing
+/// without it silently rewrites the record consumers pin against, so a repo
+/// cannot adopt snapshots and accidentally omit the safety property.
+///
+/// @dev The consuming repo's `foundry.toml` must grant read access to itself so
+/// `deployTag` can read the release version from it:
+/// `fs_permissions = [{ access = "read", path = "foundry.toml" }, ...]`
+/// alongside the usual read-write access to `src/generated`.
+library LibSnapshot {
+    /// @notice The canonical release tag: `foundry.toml` `[package].version`
+    /// with dots converted to underscores (`0.1.7` -> `0_1_7`) for the Solidity
+    /// directory form. The single definition of the tag form — the version in
+    /// `foundry.toml` is the one source of truth for which release is being
+    /// built, so the snapshot dir is derived from it rather than restated.
+    /// @param vm The Vm instance for file operations.
+    /// @return The tag.
+    function deployTag(Vm vm) internal view returns (string memory) {
+        string memory version = vm.parseTomlString(vm.readFile("foundry.toml"), ".package.version");
+        bytes memory versionBytes = bytes(version);
+        bytes memory tagBytes = new bytes(versionBytes.length);
+        for (uint256 i = 0; i < versionBytes.length; i++) {
+            tagBytes[i] = versionBytes[i] == "." ? bytes1("_") : versionBytes[i];
+        }
+        return string(tagBytes);
+    }
+
+    /// @notice The directory holding a release's frozen snapshot.
+    /// @param tag The release tag, as returned by `deployTag`.
+    /// @return The directory path as a string.
+    function dirForTag(string memory tag) internal pure returns (string memory) {
+        return string.concat("src/generated/", tag);
+    }
+
+    /// @notice The path of a contract's frozen pointers file within a release's
+    /// snapshot. Mirrors `LibFs.pathForContract` one directory deeper.
+    /// @param tag The release tag, as returned by `deployTag`.
+    /// @param contractName The name of the contract.
+    /// @return The file path as a string.
+    function frozenPathForContract(string memory tag, string memory contractName)
+        internal
+        pure
+        returns (string memory)
+    {
+        return string.concat(dirForTag(tag), "/", contractName, ".pointers.sol");
+    }
+
+    /// @notice Freeze the current generated pointers files into this release's
+    /// snapshot dir. Only the CURRENT `deployTag` dir is ever written — older
+    /// releases' snapshots are never touched.
+    ///
+    /// An existing snapshot is treated as immutable: rewriting it with IDENTICAL
+    /// content is a harmless no-op, but a DIFFERENT payload reverts. That only
+    /// happens when the generated output changed without a `[package].version`
+    /// bump — the change must bump the version so a NEW `<tag>/` dir is written
+    /// beside the frozen ones, rather than corrupting the record that consumers
+    /// of the already-published release pin against.
+    ///
+    /// @param vm The Vm instance for file operations.
+    /// @param contractNames The contracts whose generated pointers files (as
+    /// placed by `LibFs.buildFileForContract`) form this release's record.
+    function freezeSnapshot(Vm vm, string[] memory contractNames) internal {
+        string memory tag = deployTag(vm);
+        //forge-lint: disable-next-line(unsafe-cheatcode)
+        vm.createDir(dirForTag(tag), true);
+        for (uint256 i = 0; i < contractNames.length; i++) {
+            string memory frozenPath = frozenPathForContract(tag, contractNames[i]);
+            string memory content = vm.readFile(LibFs.pathForContract(contractNames[i]));
+            if (vm.exists(frozenPath)) {
+                require(
+                    keccak256(bytes(vm.readFile(frozenPath))) == keccak256(bytes(content)),
+                    "LibSnapshot: frozen snapshot would change; bump [package].version for a new release"
+                );
+            }
+            //forge-lint: disable-next-line(unsafe-cheatcode)
+            vm.writeFile(frozenPath, content);
+        }
+    }
+}

--- a/test/lib/LibSnapshot.t.sol
+++ b/test/lib/LibSnapshot.t.sol
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {LibSnapshot} from "src/lib/LibSnapshot.sol";
+import {LibFs} from "src/lib/LibFs.sol";
+
+/// @title LibSnapshotTest
+/// @notice Exercises the per-release snapshot freeze against this repo's own
+/// committed codegen example (`src/generated/CodeGennable.pointers.sol`). Each
+/// test removes the tag dir it creates so the working tree stays clean.
+contract LibSnapshotTest is Test {
+    string internal constant EXAMPLE = "CodeGennable";
+
+    function exampleNames() internal pure returns (string[] memory names) {
+        names = new string[](1);
+        names[0] = EXAMPLE;
+    }
+
+    /// External wrapper so `vm.expectRevert` can catch a revert raised inside
+    /// the internal library call.
+    function freezeExternal(string[] memory names) external {
+        LibSnapshot.freezeSnapshot(vm, names);
+    }
+
+    /// The tag is `[package].version` from foundry.toml with dots as
+    /// underscores. This repo declares 0.1.0.
+    function testDeployTagIsPackageVersionWithUnderscores() external view {
+        assertEq(LibSnapshot.deployTag(vm), "0_1_0");
+    }
+
+    function testDirAndPathForTag() external pure {
+        assertEq(LibSnapshot.dirForTag("0_1_7"), "src/generated/0_1_7");
+        assertEq(LibSnapshot.frozenPathForContract("0_1_7", "Foo"), "src/generated/0_1_7/Foo.pointers.sol");
+    }
+
+    /// The whole freeze lifecycle, in one test on purpose: the snapshot dir is
+    /// keyed off `[package].version`, so every test here would target the SAME
+    /// real directory, and cheatcode filesystem writes are not reverted between
+    /// tests. Splitting these would race on shared state rather than isolate.
+    ///
+    /// Covers: freezing copies the generated pointers file in byte for byte; an
+    /// IDENTICAL re-freeze is a harmless no-op; and the guard — if the generated
+    /// output would change without a `[package].version` bump, freezing REVERTS
+    /// rather than silently rewriting the record that consumers of the published
+    /// release pin against. That guard is the property the mechanism must never
+    /// ship without.
+    function testFreezeSnapshotLifecycle() external {
+        string memory tag = LibSnapshot.deployTag(vm);
+        string memory frozenPath = LibSnapshot.frozenPathForContract(tag, EXAMPLE);
+        string memory generated = vm.readFile(LibFs.pathForContract(EXAMPLE));
+
+        LibSnapshot.freezeSnapshot(vm, exampleNames());
+
+        assertTrue(vm.exists(frozenPath), "snapshot not written");
+        assertEq(vm.readFile(frozenPath), generated, "snapshot not byte-identical");
+
+        // Identical re-freeze must not revert.
+        LibSnapshot.freezeSnapshot(vm, exampleNames());
+        assertEq(vm.readFile(frozenPath), generated, "idempotent re-freeze changed the snapshot");
+
+        // Stand in for "the generated output changed but the version didn't":
+        // the frozen record now differs from what would be written.
+        string memory frozenRecord = "// a previously frozen release record\n";
+        vm.writeFile(frozenPath, frozenRecord);
+
+        vm.expectRevert("LibSnapshot: frozen snapshot would change; bump [package].version for a new release");
+        this.freezeExternal(exampleNames());
+
+        // The frozen record is left untouched by the reverted freeze.
+        assertEq(vm.readFile(frozenPath), frozenRecord, "reverted freeze still wrote");
+
+        vm.removeDir(LibSnapshot.dirForTag(tag), true);
+    }
+}


### PR DESCRIPTION
Closes #25.

## What

Adds `LibSnapshot` — the shared implementation of the per-release snapshot canon (`src/generated/<tag>/`):

- **`deployTag(vm)`** — `foundry.toml` `[package].version` with dots→underscores. The single definition of the tag form, replacing four identical copies.
- **`freezeSnapshot(vm, contractNames)`** — creates the tag dir, copies each generated pointers file in (via the existing `LibFs.pathForContract`), and **reverts** if a frozen file's content would change without a version bump.
- `dirForTag` / `frozenPathForContract` path helpers.

## Why here

Every consumer's `BuildPointers.sol` **already imports `LibFs`/`LibCodeGen` from this package**. `LibFs` owns *"write a generated file for a contract"*; this owns *"freeze that generated file for this release"* — the same concern, one step later.

## The divergence this fixes

| repo | `deployTag()` | freezing | immutability guard |
|---|---|---|---|
| raindex | copy | `freezeSnapshot()` | ✅ |
| st0x.deploy | copy | inline + divergent `deployTags()` (plural) | ❌ |
| rain.factory | copy | inline | ❌ |
| rain.math.float | (pending #253) | `freezeSnapshot()` | ✅ |

**The guard only exists in half of them.** In the others, regenerating over an existing tag silently rewrites the deployment record consumers of the published release pin against. Shipping the guard *with* the mechanism means a repo can't adopt snapshots and omit the safety property.

## Tests

The repo's first tests. Three: tag derivation, path construction, and the freeze lifecycle.

The lifecycle is **deliberately one test**: the snapshot dir is keyed off `[package].version`, so every test necessarily targets the *same real directory*, and cheatcode filesystem writes aren't reverted between tests — splitting them races on shared state rather than isolating (I hit exactly that). It covers freeze → byte-identical → idempotent re-freeze → tamper → guard reverts → frozen record untouched, cleans up its tag dir, and the suite passes repeatedly with no leftover state.

## Consumer note

`fs_permissions` must grant `{ access = "read", path = "foundry.toml" }` so `deployTag` can read the version (documented in the NatSpec; added here for this repo's own tests).

## Follow-ups (not this PR)

Migrating consumers to import this and delete their local copies — raindex, S01-Issuer/st0x.deploy (also reconciling its `deployTags()` divergence), rain.factory (gains the guard it lacks), rain.math.float (#253, currently adding the 4th copy). Each needs a `rain-sol-codegen` version bump + publish first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)