### PR TITLE
chore: bump [package].version to 0.1.1 to unblock autopublish

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rain-sol-codegen"
-version = "0.1.0"
+version = "0.1.1"
 
 [profile.default]
 src = 'src'

--- a/test/lib/LibSnapshot.t.sol
+++ b/test/lib/LibSnapshot.t.sol
@@ -25,9 +25,17 @@ contract LibSnapshotTest is Test {
     }
 
     /// The tag is `[package].version` from foundry.toml with dots as
-    /// underscores. This repo declares 0.1.0.
+    /// underscores.
+    ///
+    /// Asserted as a RELATIONSHIP to the declared version, never a hardcoded
+    /// literal: this repo's version bumps on every release, so a pinned literal
+    /// fails the very release that bumps it. `vm.replace` derives the expectation
+    /// by a different mechanism than the library's own dot-to-underscore loop, so
+    /// this still discriminates rather than restating the implementation.
     function testDeployTagIsPackageVersionWithUnderscores() external view {
-        assertEq(LibSnapshot.deployTag(vm), "0_1_0");
+        string memory version = vm.parseTomlString(vm.readFile("foundry.toml"), ".package.version");
+        assertTrue(bytes(version).length > 0, "no [package].version declared");
+        assertEq(LibSnapshot.deployTag(vm), vm.replace(version, ".", "_"));
     }
 
     function testDirAndPathForTag() external pure {


### PR DESCRIPTION
## Why

`Package Release` is **failing on every merge to main**, so nothing publishes. The `soldeer-gate` verdict on the LibSnapshot merge (`e2229d87`):

```
foundry.toml [package].version (0.1.0) is not ahead of the published revision
(0.1.0); the next-version lifecycle needs it to be the next UNPUBLISHED version
— bump [package].version above 0.1.0.
```

0.1.0 was published **2026-05-09** under the previous lifecycle and never received the post-publish bump, so the declared version has sat level with the published one ever since. The next-version lifecycle requires `[package].version` to be the next *unpublished* release, so the gate correctly refuses.

## Impact

`LibSnapshot` (#26) is on main but **unpublishable**, which blocks every consumer conversion that needs to import it:

- rainlanguage/raindex#2809
- S01-Issuer/st0x.deploy#251
- rainlanguage/rain.factory#45
- rainlanguage/rain.math.float#253

## What

Bump `[package].version` 0.1.0 → 0.1.1 — the next unpublished version. The gate then passes and `rain-sol-codegen@0.1.1` publishes **with `LibSnapshot`**. The reusable bumps the version onward itself after each subsequent publish, so this is a one-time correction of the stuck state, not a recurring chore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the project version to 0.1.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->