### PR TITLE
feat: add LibCodeGen.addressConstantString

### DIFF
--- a/src/lib/LibCodeGen.sol
+++ b/src/lib/LibCodeGen.sol
@@ -257,4 +257,33 @@ library LibCodeGen {
             ";\n"
         );
     }
+
+    /// Generates a Solidity address constant declaration string. Wraps the
+    /// literal in `address(...)` so the generated source is explicit about the
+    /// type rather than relying on a bare hex literal being inferred.
+    /// @param vm The Vm instance for file operations.
+    /// @param comment The comment to include above the constant declaration.
+    /// @param name The name of the constant.
+    /// @param data The address for the constant.
+    /// @return A string containing the Solidity code for the address constant.
+    function addressConstantString(Vm vm, string memory comment, string memory name, address data)
+        internal
+        pure
+        returns (string memory)
+    {
+        string memory addressString = vm.toString(data);
+        return string.concat(
+            "\n",
+            comment,
+            "\naddress constant ",
+            name,
+            " =",
+            17 + bytes(name).length + 2 + 1 + 8 + bytes(addressString).length + 2 > MAX_LINE_LENGTH
+                ? NEWLINE_DUE_TO_MAX_LENGTH
+                : " ",
+            "address(",
+            addressString,
+            ");\n"
+        );
+    }
 }

--- a/test/lib/LibCodeGen.addressConstantString.t.sol
+++ b/test/lib/LibCodeGen.addressConstantString.t.sol
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {LibCodeGen} from "src/lib/LibCodeGen.sol";
+
+/// @title LibCodeGenAddressConstantStringTest
+/// @notice `addressConstantString` emits a Solidity `address constant`
+/// declaration. The output is source code that must COMPILE, so these assert the
+/// exact emitted text rather than that it merely contains the address.
+contract LibCodeGenAddressConstantStringTest is Test {
+    function testAddressConstantString() external view {
+        assertEq(
+            LibCodeGen.addressConstantString(
+                vm, "/// @dev Some address.", "SOME_ADDRESS", address(0xc51a14251b0dcF0ae24A96b7153991378938f5F5)
+            ),
+            "\n/// @dev Some address.\naddress constant SOME_ADDRESS = address(0xc51a14251b0dcF0ae24A96b7153991378938f5F5);\n"
+        );
+    }
+
+    /// The zero address is a real value, not a sentinel to special-case.
+    function testAddressConstantStringZero() external view {
+        assertEq(
+            LibCodeGen.addressConstantString(vm, "/// @dev Zero.", "ZERO", address(0)),
+            "\n/// @dev Zero.\naddress constant ZERO = address(0x0000000000000000000000000000000000000000);\n"
+        );
+    }
+
+    /// The emitted literal is checksummed, so it round-trips back to the same
+    /// address rather than silently relying on an all-lowercase form.
+    function testAddressConstantStringRoundTrips(address data) external view {
+        string memory emitted = LibCodeGen.addressConstantString(vm, "/// @dev Fuzz.", "FUZZ", data);
+        assertEq(
+            emitted, string.concat("\n/// @dev Fuzz.\naddress constant FUZZ = address(", vm.toString(data), ");\n")
+        );
+        assertEq(vm.parseAddress(vm.toString(data)), data);
+    }
+}


### PR DESCRIPTION
## What

Adds `addressConstantString(vm, comment, name, data)` to `LibCodeGen`.

## Why

`LibCodeGen` **already owns this family** — `bytesConstantString`, `uint8ConstantString`, `bytecodeHashConstantString` — all sharing one signature and the `MAX_LINE_LENGTH` wrapping. `address` was just missing from it, so every consumer hand-rolled its own:

| repo | hand-rolls `addressConstantString` |
|---|---|
| rainlanguage/raindex | ✅ |
| rainlanguage/rain.factory | ✅ |
| S01-Issuer/st0x.deploy | ✅ |
| rainlanguage/rain.math.float | about to be the 4th (#253) |

Exactly the shape that produced the `deployTag`/`freezeSnapshot` fragmentation this repo just absorbed as `LibSnapshot` (#26): a helper that belongs in the shared codegen library, re-implemented per repo instead.

It wraps the literal in `address(...)`, matching what the consumers already emit, so the generated source is explicit about the type rather than leaning on a bare hex literal being inferred.

## Tests

Assert the **exact emitted text**, not that the output merely contains the address — this generates Solidity that must compile, so a formatting slip is a real break that a loose assertion would sail past. Plus a fuzz over `address` confirming the emitted literal round-trips through `parseAddress` (the checksummed form is what makes the generated source valid), and the zero address treated as a real value rather than a special case.

## Follow-ups

Consumers drop their local copies when they convert — raindex#2809, S01-Issuer/st0x.deploy#251, rain.factory#45, and rain.math.float#253 (which will import it rather than add the fourth copy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)