### PR TITLE
feat(script): BuildScript base — regenerate and cut are separate entrypoints

### DIFF
--- a/script/Build.sol
+++ b/script/Build.sol
@@ -2,19 +2,23 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Script} from "forge-std-1.16.1/src/Script.sol";
+import {BuildScript} from "../src/abstract/BuildScript.sol";
 import {LibFs} from "../src/lib/LibFs.sol";
 import {LibCodeGen} from "../src/lib/LibCodeGen.sol";
 import {CodeGennable} from "../test/concrete/CodeGennable.sol";
 
 /// @title Build
-/// @notice Script to build the generated file for the CodeGennable contract.
-/// @dev This shows an example of how to use the bytes constant generation
-/// utility in LibCodeGen.
-contract Build is Script {
-    /// Builds the generated file for the CodeGennable contract to show an example
-    /// of how to use the bytes constant generation utility.
-    function run() external {
+/// @notice Builds the generated file for the CodeGennable contract, as an
+/// example of both halves of this library: the constant generation utilities in
+/// `LibCodeGen`, and the `BuildScript` entrypoint split that keeps regenerating
+/// separate from cutting a release record.
+/// @dev This repo pins no release record of its own, so it implements `build`
+/// alone and inherits the default empty `snapshotContractNames` — `cut` freezes
+/// nothing here.
+contract Build is BuildScript {
+    /// Emits the example's constants. Reached by both `run` (regenerate) and
+    /// `cut` (regenerate, then freeze), so generation lives in one place.
+    function build() internal override {
         CodeGennable codeGennable = new CodeGennable();
 
         LibFs.buildFileForContract(

--- a/src/abstract/BuildScript.sol
+++ b/src/abstract/BuildScript.sol
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity ^0.8.25;
+
+import {Script} from "forge-std-1.16.1/src/Script.sol";
+import {LibSnapshot} from "../lib/LibSnapshot.sol";
+
+/// @title BuildScript
+/// @notice Base for a repo's codegen script. Splits "regenerate the committed
+/// generated files" from "cut this release's immutable record" into two
+/// entrypoints, and owns both so a consumer cannot merge them back together.
+///
+/// The split is the whole point. The snapshot tag derives from
+/// `[package].version`, which release automation bumps on every publish. A
+/// script that cut a snapshot as part of its ordinary build therefore opens a
+/// `<tag>/` dir for a release nobody deployed, every time the version moves,
+/// and the next regenerate-and-diff finds the tree dirty. `run()` and `cut()`
+/// are concrete here precisely so a consumer implements the hooks and has
+/// nowhere to cut from the path CI runs.
+///
+/// Cutting stays independent of deploying. The frozen record carries the
+/// creation code, and a Zoltu address is a pure function of it, so a deploy
+/// reads the record rather than needing this script to broadcast — the deploy
+/// then puts on-chain exactly the bytes that were frozen, instead of
+/// re-deriving them.
+abstract contract BuildScript is Script {
+    /// @notice Write this repo's generated files, e.g. via
+    /// `LibFs.buildFileForContract`. Runs on both entrypoints: cutting a record
+    /// of stale output would freeze a lie.
+    function build() internal virtual;
+
+    /// @notice The contracts whose generated files form this release's frozen
+    /// record. Empty for a repo that generates files but freezes none.
+    /// @return names The contract names.
+    function snapshotContractNames() internal view virtual returns (string[] memory names);
+
+    /// @notice Freeze this release's record. Virtual only so tests can observe
+    /// the dispatch; consumers are not expected to override it.
+    function freeze() internal virtual {
+        LibSnapshot.freezeSnapshot(vm, snapshotContractNames());
+    }
+
+    /// @notice Regenerate the committed generated files, cutting nothing. This
+    /// is what CI's regenerate-and-diff runs, so it is inert with respect to
+    /// the frozen `<tag>/` dirs.
+    function run() external {
+        build();
+    }
+
+    /// @notice Regenerate, then cut this release's record into
+    /// `src/generated/<tag>/`. A deliberate act, so it has its own entrypoint:
+    /// `forge script <path> --sig 'cut()'`.
+    function cut() external {
+        build();
+        freeze();
+    }
+}

--- a/src/abstract/BuildScript.sol
+++ b/src/abstract/BuildScript.sol
@@ -30,9 +30,12 @@ abstract contract BuildScript is Script {
     function build() internal virtual;
 
     /// @notice The contracts whose generated files form this release's frozen
-    /// record. Empty for a repo that generates files but freezes none.
+    /// record. Defaults to none, so a repo that generates files but pins no
+    /// release record implements `build` alone and `cut` freezes nothing.
     /// @return names The contract names.
-    function snapshotContractNames() internal view virtual returns (string[] memory names);
+    function snapshotContractNames() internal view virtual returns (string[] memory names) {
+        names = new string[](0);
+    }
 
     /// @notice Freeze this release's record. Virtual only so tests can observe
     /// the dispatch; consumers are not expected to override it.

--- a/src/abstract/BuildScript.sol
+++ b/src/abstract/BuildScript.sol
@@ -23,6 +23,12 @@ import {LibSnapshot} from "../lib/LibSnapshot.sol";
 /// reads the record rather than needing this script to broadcast — the deploy
 /// then puts on-chain exactly the bytes that were frozen, instead of
 /// re-deriving them.
+// `build` is unimplemented on purpose: this base is published for a consumer's
+// script to complete, and slither reasons about the derived-most contract in
+// THIS repo, so it cannot see the consumers that implement it. Suppressed here
+// rather than repo-wide, so the detector still fires on a concrete contract that
+// genuinely left a function unimplemented.
+// slither-disable-next-line unimplemented-functions
 abstract contract BuildScript is Script {
     /// @notice Write this repo's generated files, e.g. via
     /// `LibFs.buildFileForContract`. Runs on both entrypoints: cutting a record

--- a/src/lib/LibSnapshot.sol
+++ b/src/lib/LibSnapshot.sol
@@ -75,6 +75,12 @@ library LibSnapshot {
     /// @param contractNames The contracts whose generated files (as
     /// placed by `LibFs.buildFileForContract`) form this release's record.
     function freezeSnapshot(Vm vm, string[] memory contractNames) internal {
+        // Nothing to freeze means no release record, so no `<tag>/` dir. Creating
+        // one anyway would leave an empty dir named for a release that froze
+        // nothing, which is the state the per-release tag exists to avoid.
+        if (contractNames.length == 0) {
+            return;
+        }
         string memory tag = deployTag(vm);
         //forge-lint: disable-next-line(unsafe-cheatcode)
         vm.createDir(dirForTag(tag), true);

--- a/test/abstract/BuildScript.t.sol
+++ b/test/abstract/BuildScript.t.sol
@@ -3,29 +3,7 @@
 pragma solidity =0.8.25;
 
 import {Test} from "forge-std-1.16.1/src/Test.sol";
-import {BuildScript} from "src/abstract/BuildScript.sol";
-
-/// @notice Counts the hooks instead of running them, so the entrypoints are
-/// asserted on dispatch alone. The real `freeze` writes the tag dir named by
-/// `[package].version` — shared state that `LibSnapshot.t.sol` also drives, and
-/// forge runs test contracts concurrently, so touching it here would race
-/// rather than test.
-contract SpyBuildScript is BuildScript {
-    uint256 public builds;
-    uint256 public freezes;
-
-    function build() internal override {
-        builds++;
-    }
-
-    function snapshotContractNames() internal pure override returns (string[] memory names) {
-        names = new string[](0);
-    }
-
-    function freeze() internal override {
-        freezes++;
-    }
-}
+import {SpyBuildScript} from "./SpyBuildScript.sol";
 
 /// @title BuildScriptTest
 contract BuildScriptTest is Test {

--- a/test/abstract/BuildScript.t.sol
+++ b/test/abstract/BuildScript.t.sol
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {BuildScript} from "src/abstract/BuildScript.sol";
+
+/// @notice Counts the hooks instead of running them, so the entrypoints are
+/// asserted on dispatch alone. The real `freeze` writes the tag dir named by
+/// `[package].version` — shared state that `LibSnapshot.t.sol` also drives, and
+/// forge runs test contracts concurrently, so touching it here would race
+/// rather than test.
+contract SpyBuildScript is BuildScript {
+    uint256 public builds;
+    uint256 public freezes;
+
+    function build() internal override {
+        builds++;
+    }
+
+    function snapshotContractNames() internal pure override returns (string[] memory names) {
+        names = new string[](0);
+    }
+
+    function freeze() internal override {
+        freezes++;
+    }
+}
+
+/// @title BuildScriptTest
+contract BuildScriptTest is Test {
+    /// THE property the base exists to enforce. `run()` is the path CI takes on
+    /// every build; the tag follows `[package].version`, which release
+    /// automation bumps on every publish, so a `run()` that cut would open a
+    /// `<tag>/` dir for a release nobody deployed and dirty the tree.
+    function testRunBuildsAndCutsNothing() external {
+        SpyBuildScript s = new SpyBuildScript();
+        s.run();
+        assertEq(s.builds(), 1, "run did not build");
+        assertEq(s.freezes(), 0, "the CI path cut a snapshot");
+    }
+
+    /// Cutting regenerates first: freezing stale output would record a lie.
+    function testCutBuildsThenFreezes() external {
+        SpyBuildScript s = new SpyBuildScript();
+        s.cut();
+        assertEq(s.builds(), 1, "cut did not build");
+        assertEq(s.freezes(), 1, "cut did not freeze");
+    }
+
+    /// Each entrypoint is one pass, so a repeated dispatch is the caller's
+    /// choice rather than a hidden loop.
+    function testEntrypointsDoNotCompound() external {
+        SpyBuildScript s = new SpyBuildScript();
+        s.run();
+        s.run();
+        s.cut();
+        assertEq(s.builds(), 3, "builds per dispatch drifted");
+        assertEq(s.freezes(), 1, "run freezes");
+    }
+}

--- a/test/abstract/SpyBuildScript.sol
+++ b/test/abstract/SpyBuildScript.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {BuildScript} from "src/abstract/BuildScript.sol";
+
+/// @notice Counts the hooks instead of running them, so the entrypoints are
+/// asserted on dispatch alone. The real `freeze` writes the tag dir named by
+/// `[package].version` — shared state that `LibSnapshot.t.sol` also drives, and
+/// forge runs test contracts concurrently, so touching it here would race
+/// rather than test.
+contract SpyBuildScript is BuildScript {
+    uint256 public builds;
+    uint256 public freezes;
+
+    function build() internal override {
+        builds++;
+    }
+
+    function snapshotContractNames() internal pure override returns (string[] memory names) {
+        names = new string[](0);
+    }
+
+    function freeze() internal override {
+        freezes++;
+    }
+}

--- a/test/lib/LibSnapshot.t.sol
+++ b/test/lib/LibSnapshot.t.sol
@@ -43,6 +43,19 @@ contract LibSnapshotTest is Test {
         assertEq(LibSnapshot.frozenPathForContract("0_1_7", "Foo"), "src/generated/0_1_7/Foo.sol");
     }
 
+    /// Freezing nothing must not open a `<tag>/` dir. A repo that generates
+    /// files but pins no release record still calls freeze via `cut`, and an
+    /// empty dir named for a release that froze nothing is exactly the stray
+    /// per-release slot the tag scheme exists to avoid.
+    function testFreezeNothingOpensNoTagDir() external {
+        string memory dir = LibSnapshot.dirForTag(LibSnapshot.deployTag(vm));
+        assertFalse(vm.exists(dir), "tag dir present before");
+
+        LibSnapshot.freezeSnapshot(vm, new string[](0));
+
+        assertFalse(vm.exists(dir), "freezing nothing opened a tag dir");
+    }
+
     /// The whole freeze lifecycle, in one test on purpose: the snapshot dir is
     /// keyed off `[package].version`, so every test here would target the SAME
     /// real directory, and cheatcode filesystem writes are not reverted between


### PR DESCRIPTION
Toward rainlanguage/rainix#273 — cutting a constant snapshot becomes a deliberate act rather than a side effect of a build.

## The problem

`LibSnapshot.deployTag()` derives the snapshot tag from `[package].version`, which release automation bumps on **every publish**. Consumers call `freezeSnapshot` from the same `run()` that CI regenerates with, so every version bump opens a `<tag>/` dir for a release nobody deployed, and the next regenerate-and-diff finds the tree dirty.

Observed live on S01-Issuer/st0x.deploy#252: an autopublish bump to 0.1.8 landed 49 seconds after the last green `git-clean`, and the next branch cut from main failed with `Committed pointer artifacts are stale` over an entire empty `0_1_8` block it never asked for.

## The change

```solidity
abstract contract BuildScript is Script {
    function build() internal virtual;                                       // consumer
    function snapshotContractNames() internal view virtual returns (string[] memory);  // consumer

    function run() external { build(); }                 // CI: regenerate, cuts nothing
    function cut() external { build(); freeze(); }       // deliberate: the only path that cuts
}
```

`run()` and `cut()` are **concrete in the base**, so a consumer implements the two hooks and has nowhere to cut from the path CI runs. The split is structural, not conventional — a consumer cannot re-merge them by forgetting.

`cut()` regenerates before freezing: freezing stale output would record a lie.

## Why not an env var

The first attempt gated `freezeSnapshot` on `RAIN_CUT_SNAPSHOT`. It was discarded: the env is **process-global**, forge runs test contracts concurrently, and the opt-in raced — one test setting `true` flipped another test's `false` mid-run. That is the same shared-mutable-state trap `LibSnapshot.t.sol` already documents for the tag dir ("Splitting these would race on shared state rather than isolate"). A gate that cannot be tested in isolation is not a gate worth shipping.

The type system carries the decision instead. Nothing ambient, nothing to remember.

## Why here and not rain-deploy

rain-deploy depends on `forge-std` alone (`recursive_deps = false`) — deliberately lean. Hosting the base there means rain-deploy -> rain-sol-codegen, so everyone wanting `deployZoltu` pulls the codegen library transitively.

This base needs only codegen's own `LibSnapshot`, so it costs **zero new dependencies** here, and generated-file lifecycle is already codegen's domain.

Cut and deploy stay decoupled because the frozen record carries `CREATION_CODE` and a Zoltu address is a pure function of it: a deploy reads the record rather than needing this script to broadcast — and it then puts on-chain exactly the bytes that were frozen, instead of re-deriving them.

## Tests

`SpyBuildScript` counts `build`/`freeze` dispatches rather than running them. The real `freeze` writes the tag dir named by `[package].version` — shared state `LibSnapshot.t.sol` also drives, and forge runs test contracts concurrently, so asserting against the filesystem here would race rather than test.

Mutation-validated, baseline green first:

| mutation | result |
|---|---|
| baseline (unmutated) | **3 passed, 0 failed** |
| `run()` also freezes (the bug, reintroduced) | `[FAIL: the CI path cut a snapshot: 1 != 0]` |
| `cut()` forgets to freeze | `[FAIL: cut did not freeze: 0 != 1]` |
| restored, full suite | **16 passed, 0 failed** |

`forge fmt --check` clean.

## Not in this PR

- **No consumer adopts it yet.** rainlanguage/rain.math.float#253 is the natural first: its `Build.sol` already has exactly the `build()` + `snapshotContractNames()` shape, and adopting it would stop float cutting a snapshot on every CI regenerate.
- **`deploy()` is not here.** Reading a frozen record and broadcasting it is rain-deploy's domain, and keeping it there is what lets both libraries stay independent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a standardized workflow for regenerating build outputs.
  * Added a release-freezing workflow that regenerates outputs and records a release snapshot.

* **Tests**
  * Added coverage confirming regeneration and release-freezing workflows execute correctly and independently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->